### PR TITLE
Use ggrepel for team labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It compares actual coaching decisions to an analytics-based recommendation model
 ## Technologies Used
 
 - **R** / **Shiny**
-- `nflfastR`, `tidyverse`, `gt`, `plotly`, `ggimage`, `DT`
+- `nflfastR`, `tidyverse`, `gt`, `plotly`, `ggimage`, `ggrepel`, `DT`
 - Hosted on **[shinyapps.io](https://shinyapps.io)**  
 - Version-controlled via **GitHub**
 


### PR DESCRIPTION
## Summary
- add `ggrepel` library
- switch text labels to `geom_text_repel`
- compute point size inside data to avoid linewidth warnings
- keep only selected team label repelled

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685266df67708320973c4aa88ec16765