### PR TITLE
Read Supabase creds from .Renviron

### DIFF
--- a/.Renviron
+++ b/.Renviron
@@ -1,0 +1,2 @@
+SUPABASE_URL=your_supabase_url
+SUPABASE_KEY=your_supabase_key

--- a/README.md
+++ b/README.md
@@ -17,8 +17,16 @@ It compares actual coaching decisions to an analytics-based recommendation model
 
 - **R** / **Shiny**
 - `nflfastR`, `tidyverse`, `gt`, `plotly`, `ggimage`, `ggrepel`, `DT`
-- Hosted on **[shinyapps.io](https://shinyapps.io)**  
+- Hosted on **[shinyapps.io](https://shinyapps.io)**
 - Version-controlled via **GitHub**
+
+## Supabase Integration
+
+Play-by-play data must be stored in a Supabase table named `pbp`. Create a
+`.Renviron` file in the project directory containing the variables
+`SUPABASE_URL` and `SUPABASE_KEY`. The app reads these credentials at startup
+and fetches the data using Supabase's REST API. If the request fails, the app
+will display an error.
 
 ## Screenshots
 


### PR DESCRIPTION
## Summary
- load play-by-play data from Supabase automatically at startup
- remove credential inputs from the home page
- document storing `SUPABASE_URL` and `SUPABASE_KEY` in `.Renviron`
- include a sample `.Renviron` file

## Testing
- `R -q -e "cat('R check\n')"` *(fails: R not installed)*
- `git status --short`
